### PR TITLE
Automatically obtain gam path and architecture, and variably display changelog output

### DIFF
--- a/updategam7.ps1
+++ b/updategam7.ps1
@@ -9,17 +9,34 @@
 # Check the version of GAM7 and update if new version exists
 ## There's now an ARM version for Windows, so code needed one more variable.
 
-# This variable MUST be adjusted to match your system.
-# Where is GAM7 installed?
-$dir = "D:\gam7"
-# Disable this line to make the script work after adjusting the $dir variable above.
-Write-Host 'You must adjust the $dir variable. Then disable this line.'; Exit
+# Set this to $false if you do not want to see the change log output
+$ShowChangeLog = $true
 
-# What type of Windows do you have, X86 or ARM? Uncomment the correct one below.
-# $winversion = "windows-arm64.zip"
-# $winversion = "windows-x86_64.zip"
-# Disable this line to make the script work after adjusting the $winversion variable above.
-Write-Host 'You must uncomment the correct $winversion variable. Then disable this line.'; Exit
+# If GAM's installation location cannot be automatically located, then this variable MUST be adjusted to match your system.
+# Where is GAM7 installed?
+$dir = ""
+
+# Try to automatically find the install location for GAM
+$gam = Get-Command gam -ErrorAction SilentlyContinue
+if (-not $gam -or -not $gam.Source) {
+  if ($dir -and -not (Test-Path $dir -PathType Container)) {
+    throw "$dir not found or is not a valid folder path. Edit this script located at $PSCommandPath to manually set the `$dir variable value to an existing folder path"
+  } elseif (-not $dir) {
+    throw "Unable to automatically locate GAM installation location. Manually (re)install GAM, or edit this script located at $PSCommandPath to manually set the `$dir variable value"
+  }
+} else {
+  $dir = Split-Path $gam.Source -Parent
+}
+
+# Automatically determine which Windows architecture version to download
+$architecture = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
+$winversion = switch ($architecture) {
+    "X64"  { "windows-x86_64.zip" }
+    "X86"  { "windows-x86_64.zip" }
+    "Arm"  { "windows-arm64.zip" }
+    "Arm64" { "windows-arm64.zip" }
+    Default { throw "Unknown Windows architecture. You may need to manually specify the `$winversion variable in $PSCommandPath" }
+}
 
 # HERE BE DRAGONS!
 # Do not change anything below.
@@ -39,30 +56,32 @@ if ($lastexitcode -eq 1) {
   # Get the download URL for the latest release.
   $dlurl = ($releases[0].assets | where {$_.name -like "*$winversion"}).browser_download_url
   # Download the latest release.
-  (New-Object System.Net.WebClient).DownloadFile($dlurl, "$dir\gam7-latest-windows-x86_64.zip")
+  (New-Object System.Net.WebClient).DownloadFile($dlurl, "$dir\gam7-latest-$winversion")
   
     # Save the number of lines in the current change log. Disable if script is to run automatically.
   $oldchangeloglinescount=(Get-Content $dir\GamUpdate.txt | Select-String .*).count
   
   # Extract the contents of the zip file to a temporary directory.
   # The \gam7 path is included in the zip and may have to be adjusted if it's changed in the future.
-  Expand-Archive "$dir\gam7-latest-windows-x86_64.zip" "$dir\" -Force
+  Expand-Archive "$dir\gam7-latest-$winversion" "$dir\" -Force
   # Copy the extracted files to the current location.
   Copy-Item "$dir\gam7\*" "$dir\" -Force -Recurse
   # Remove the temporary directory.
   rm "$dir\gam7" -Force -Recurse
   
-  # Save the number of lines in the updated change log. Disable if script is to run automatically.
-  $newchangeloglinescount=(Get-Content $dir\GamUpdate.txt | Select-String .*).count
-  # Get and display the new lines in the change log. Disable if script is to run automatically.
-  Write-Host "Latest Changes in GAM7" -ForegroundColor Red -BackgroundColor White
-  Get-Content $dir\GamUpdate.txt -Head ($newchangeloglinescount-$oldchangeloglinescount)
+  if ($ShowChangeLog -eq $true) {
+    # Save the number of lines in the updated change log.
+    $newchangeloglinescount=(Get-Content $dir\GamUpdate.txt | Select-String .*).count
+    # Get and display the new lines in the change log.
+    Write-Host "Latest Changes in GAM7" -ForegroundColor Red -BackgroundColor White
+    Get-Content $dir\GamUpdate.txt -Head ($newchangeloglinescount-$oldchangeloglinescount)
+  }
 
   # Display a message saying that GAM7 has been updated, then pause. Disable if script is to run automatically.
   Write-Host "GAM7 has been updated" -ForegroundColor Red -BackgroundColor White
 } else {
   # Display a message saying GAM7 is already up-to-date, then pause. Disable if script is to run automatically.
-    Write-Host "GAM7 is already up-to-date" -ForegroundColor Green
+  Write-Host "GAM7 is already up-to-date" -ForegroundColor Green
 
 }
 # If the script is to be run automatically, disable the Pause.


### PR DESCRIPTION
1. Automatically determines gam path if gam is properly added to $path or otherwise recognized by Powershell as a command. If not, an error will be thrown instructing the user to manually specify the $dir variable in the script file.
2. Automatically determines whether the current Windows system is an x86_x64 architecture, or ARM architecture, and specifies the correct zip version accordingly. An error will be thrown with (admittedly kind of vague) instructions to manually specify the variable if the architecture is unknown.
3. Moved the changelog output so it is shown based on a true/false variable, making it easier to disable the output if desired.